### PR TITLE
Support pointers and nested structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,24 @@ Or you can provide an environment variable with the suffix `_FILE` that contains
 export MY_APP_DATABASE_CONNECTION_STRING_FILE="/path/to/a/file.txt"
 ```
 
-## Limitations
+### Nested Structs
 
-The implementation is currenly very basic. Field types can only be primitives.
+Nested structs are also supported:
+
+```go
+type DatabaseConfig struct {
+	User     string `required:"true"`
+	Password string `required:"true"`
+}
+
+type MyConfig struct {
+	Database       DatabaseConfig
+	TimeoutSeconds int            `default:"10"`
+}
+```
+
+The properties can be set with these environment variables:
+
+- `MY_APP_DATABASE_USER` or `MY_APP_DATABASE_USER_FILE`
+- `MY_APP_DATABASE_PASSWORD` or `MY_APP_DATABASE_PASSWORD_FILE`
+- `MY_APP_TIMEOUT` or `MY_APP_TIMEOUT_FILE`

--- a/pathenvconfig_test.go
+++ b/pathenvconfig_test.go
@@ -45,21 +45,24 @@ func TestFieldNameToVariable(t *testing.T) {
 }
 
 type ConfigSpec struct {
-	Name  string `required:"true"`
-	Age   int    `default:"13"`
-	IsDog bool
+	Name   string `required:"true"`
+	Age    int    `default:"13"`
+	IsDog  bool
+	Weight *int
 }
 
 func TestEnvionmentVariables(t *testing.T) {
 	setVariable(t.Name(), "NAME", "Oona")
 	setVariable(t.Name(), "AGE", "3")
 	setVariable(t.Name(), "IS_DOG", "true")
+	setVariable(t.Name(), "WEIGHT", "50")
 
 	spec := ConfigSpec{}
 	require.Nil(t, Process(t.Name(), &spec))
 	assert.Equal(t, "Oona", spec.Name)
 	assert.Equal(t, 3, spec.Age)
 	assert.True(t, spec.IsDog)
+	assert.Equal(t, 50, *spec.Weight)
 }
 
 func TestEnvionmentVariablesNoPrefix(t *testing.T) {
@@ -121,4 +124,28 @@ func TestValueWithSpaces(t *testing.T) {
 
 func setVariable(prefix, name, value string) {
 	os.Setenv(fmt.Sprintf("%s_%s", prefix, name), value)
+}
+
+type DatabaseConfig struct {
+	User     string
+	Password string
+}
+
+type WithNesteStruct struct {
+	Db     DatabaseConfig
+	DbPtr  *DatabaseConfig
+	DbPtr2 *DatabaseConfig
+	DbPtr3 *DatabaseConfig
+}
+
+func TestNestedMap(t *testing.T) {
+	setVariable(t.Name(), "DB_USER", "Oscar")
+	setVariable(t.Name(), "DB_PTR_USER", "Bert")
+
+	spec := WithNesteStruct{DbPtr3: &DatabaseConfig{}}
+	require.Nil(t, Process(t.Name(), &spec))
+	assert.Equal(t, "Oscar", spec.Db.User)
+	assert.Equal(t, "Bert", spec.DbPtr.User)
+	assert.Nil(t, spec.DbPtr2)
+	assert.NotNil(t, spec.DbPtr3)
 }


### PR DESCRIPTION
Adding support for nested structs:
```go
type DatabaseConfig struct {
	User     string `required:"true"`
	Password string `required:"true"`
}

type MyConfig struct {
	Database       DatabaseConfig
	TimeoutSeconds int            `default:"10"`
}
```

Also adding support for pointer fields.